### PR TITLE
Fix the Font weight can be 400ii issue

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -169,6 +169,15 @@ function ogf_fonts_array() {
 			'700italic',
 			'800italic',
 			'900italic',
+			'100i',
+			'200i',
+			'300i',
+			'400i',
+			'500i',
+			'600i',
+			'700i',
+			'800i',
+			'900i'
 		);
 
 		// remove italic variants.


### PR DESCRIPTION
The font.json (https://github.com/fontsplugin/plugin/blob/master/blocks/src/google-fonts/fonts.json) has many data like '400i'.
In the class-ogf-fonts.php, the ``` get_font_weights() ```  method will add another `i` to let the weight be `400ii` (https://github.com/fontsplugin/plugin/blob/c6dee1f9338e513fd46bebd16eed79b64a574c2c/includes/class-ogf-fonts.php#L97).
So, these `400i` names should be removed first